### PR TITLE
Allow updating of boolean/integer attributes to 0.

### DIFF
--- a/wspp/server.class.php
+++ b/wspp/server.class.php
@@ -2415,7 +2415,7 @@ EOSS;
 
                         //GROS PB avec le record rempli de 0 !!!!
                         foreach ($course as $key => $value) {
-                            if (empty ($value))
+                            if (!is_int($value) && empty ($value))
                                 unset ($course-> $key);
                         }
                         // in Moodle 2.0 update_course returns nothing !


### PR DESCRIPTION
I'm trying to use the web service to change course visibility from "Available to students" (1) to "Not available to students (0). It seems that this is not possible due to the following code in lines 2416-2420 of `server.class.php`:

```
//GROS PB avec le record rempli de 0 !!!!
foreach ($course as $key => $value) {
    if (empty ($value))
        unset ($course-> $key);
}
```

These lines were originally added in commit 08dcd1d868083a0bc0be28a1b1312bdbe32f95b6.

The use of `empty($value)` means that this test will always evaluate to true for the integer, 0 and it is impossible to set boolean flags to 0/FALSE.

One possible fix would be to do a type test and allow the integer 0 to stay set:

```
foreach ($course as $key => $value) {
    if (!is_int($value) && empty ($value))
        unset ($course-> $key);
}
```

Thoughts?
