### PR TITLE
Expose Group and Grouping idnumber attributes

### DIFF
--- a/wspp/classes/groupDatum.php
+++ b/wspp/classes/groupDatum.php
@@ -24,6 +24,10 @@ class groupDatum {
 	/** 
 	* @var string
 	*/
+	public $idnumber;
+	/** 
+	* @var string
+	*/
 	public $description;
 	/** 
 	* @var string
@@ -46,6 +50,7 @@ class groupDatum {
 		 $this->id=0;
 		 $this->courseid=0;
 		 $this->name='';
+		 $this->idnumber='';
 		 $this->description='';
 		 $this->enrolmentkey='';
 		 $this->picture=0;
@@ -82,6 +87,14 @@ class groupDatum {
 	*/
 	public function getName(){
 		 return $this->name;
+	}
+
+
+	/**
+	* @return string
+	*/
+	public function getIdnumber(){
+		 return $this->idnumber;
 	}
 
 
@@ -151,6 +164,15 @@ class groupDatum {
 	*/
 	public function setName($name){
 		$this->name=$name;
+	}
+
+
+	/**
+	* @param string $idnumber
+	* @return void
+	*/
+	public function setIdnumber($idnumber){
+		$this->idnumber=$idnumber;
 	}
 
 

--- a/wspp/classes/groupRecord.php
+++ b/wspp/classes/groupRecord.php
@@ -24,6 +24,10 @@ class groupRecord {
 	/** 
 	* @var string
 	*/
+	public $idnumber;
+	/** 
+	* @var string
+	*/
 	public $description;
 	/** 
 	* @var integer
@@ -54,6 +58,7 @@ class groupRecord {
 		 $this->id=0;
 		 $this->courseid=0;
 		 $this->name='';
+		 $this->idnumber='';
 		 $this->description='';
 		 $this->picture=0;
 		 $this->hidepicture=0;
@@ -92,6 +97,14 @@ class groupRecord {
 	*/
 	public function getName(){
 		 return $this->name;
+	}
+
+
+	/**
+	* @return string
+	*/
+	public function getIdnumber(){
+		 return $this->idnumber;
 	}
 
 
@@ -177,6 +190,15 @@ class groupRecord {
 	*/
 	public function setName($name){
 		$this->name=$name;
+	}
+
+
+	/**
+	* @param string $idnumber
+	* @return void
+	*/
+	public function setIdnumber($idnumber){
+		$this->idnumber=$idnumber;
 	}
 
 

--- a/wspp/classes/groupingDatum.php
+++ b/wspp/classes/groupingDatum.php
@@ -24,6 +24,10 @@ class groupingDatum {
 	/** 
 	* @var string
 	*/
+	public $idnumber;
+	/** 
+	* @var string
+	*/
 	public $description;
 
 	/**
@@ -34,6 +38,7 @@ class groupingDatum {
 		 $this->id=0;
 		 $this->courseid=0;
 		 $this->name='';
+		 $this->idnumber='';
 		 $this->description='';
 	}
 	/* get accessors */
@@ -67,6 +72,14 @@ class groupingDatum {
 	*/
 	public function getName(){
 		 return $this->name;
+	}
+
+
+	/**
+	* @return string
+	*/
+	public function getIdnumber(){
+		 return $this->idnumber;
 	}
 
 
@@ -112,6 +125,15 @@ class groupingDatum {
 	*/
 	public function setName($name){
 		$this->name=$name;
+	}
+
+
+	/**
+	* @param string $idnumber
+	* @return void
+	*/
+	public function setIdnumber($idnumber){
+		$this->idnumber=$idnumber;
 	}
 
 

--- a/wspp/classes/groupingRecord.php
+++ b/wspp/classes/groupingRecord.php
@@ -24,6 +24,10 @@ class groupingRecord {
 	/** 
 	* @var string
 	*/
+	public $idnumber;
+	/** 
+	* @var string
+	*/
 	public $description;
 	/** 
 	* @var string
@@ -46,6 +50,7 @@ class groupingRecord {
 		 $this->id=0;
 		 $this->courseid=0;
 		 $this->name='';
+		 $this->idnumber='';
 		 $this->description='';
 		 $this->configdata='';
 		 $this->timecreated=0;
@@ -151,6 +156,15 @@ class groupingRecord {
 	*/
 	public function setName($name){
 		$this->name=$name;
+	}
+
+
+	/**
+	* @param string $idnumber
+	* @return void
+	*/
+	public function setIdnumber($idnumber){
+		$this->idnumber=$idnumber;
 	}
 
 

--- a/wspp/moodle2integration/oktech/oktech_classeslib.php
+++ b/wspp/moodle2integration/oktech/oktech_classeslib.php
@@ -508,6 +508,7 @@ class oktech_groupingDatum extends external_single_structure {
 	 'description'		=>	new external_value(PARAM_CLEAN,'',VALUE_OPTIONAL),//xsd:string 
 	 'id'		=>	new external_value(PARAM_INT,'',VALUE_OPTIONAL),//xsd:int 
 	 'name'		=>	new external_value(PARAM_CLEAN,'',VALUE_OPTIONAL),//xsd:string
+	 'idnumber'		=>	new external_value(PARAM_CLEAN,'',VALUE_OPTIONAL),//xsd:string 
 
 	    );
 		parent::__construct($content, $desc,VALUE_REQUIRED,null);
@@ -532,6 +533,7 @@ class oktech_groupingRecord extends external_single_structure {
 	 'error'		=>	new external_value(PARAM_CLEAN,'',VALUE_OPTIONAL),//xsd:string 
 	 'id'		=>	new external_value(PARAM_INT,'',VALUE_OPTIONAL),//xsd:int 
 	 'name'		=>	new external_value(PARAM_CLEAN,'',VALUE_OPTIONAL),//xsd:string 
+	 'idnumber'		=>	new external_value(PARAM_CLEAN,'',VALUE_OPTIONAL),//xsd:string 
 	 'timecreated'		=>	new external_value(PARAM_INT,'',VALUE_OPTIONAL),//xsd:int 
 	 'timemodified'		=>	new external_value(PARAM_INT,'',VALUE_OPTIONAL),//xsd:int
 

--- a/wspp/moodle2integration/oktech/oktech_classeslib.php
+++ b/wspp/moodle2integration/oktech/oktech_classeslib.php
@@ -461,6 +461,7 @@ class oktech_groupDatum extends external_single_structure {
 	 'hidepicture'		=>	new external_value(PARAM_INT,'',VALUE_OPTIONAL),//xsd:int 
 	 'id'		=>	new external_value(PARAM_INT,'',VALUE_OPTIONAL),//xsd:int 
 	 'name'		=>	new external_value(PARAM_CLEAN,'',VALUE_OPTIONAL),//xsd:string 
+	 'idnumber'		=>	new external_value(PARAM_CLEAN,'',VALUE_OPTIONAL),//xsd:string 
 	 'picture'		=>	new external_value(PARAM_INT,'',VALUE_OPTIONAL),//xsd:int
 
 	    );
@@ -487,6 +488,7 @@ class oktech_groupRecord extends external_single_structure {
 	 'hidepicture'		=>	new external_value(PARAM_INT,'',VALUE_OPTIONAL),//xsd:int 
 	 'id'		=>	new external_value(PARAM_INT,'',VALUE_OPTIONAL),//xsd:int 
 	 'name'		=>	new external_value(PARAM_CLEAN,'',VALUE_OPTIONAL),//xsd:string 
+	 'idnumber'		=>	new external_value(PARAM_CLEAN,'',VALUE_OPTIONAL),//xsd:string 
 	 'picture'		=>	new external_value(PARAM_INT,'',VALUE_OPTIONAL),//xsd:int 
 	 'timecreated'		=>	new external_value(PARAM_INT,'',VALUE_OPTIONAL),//xsd:int 
 	 'timemodified'		=>	new external_value(PARAM_INT,'',VALUE_OPTIONAL),//xsd:int

--- a/wspp/moodlewsdl.xml
+++ b/wspp/moodlewsdl.xml
@@ -126,6 +126,7 @@
 					<xsd:element name="id" type="xsd:int" />
 					<xsd:element name="courseid" type="xsd:int" />
 					<xsd:element name="name" type="xsd:string" />
+					<xsd:element name="idnumber" type="xsd:string" />
 					<xsd:element name="description" type="xsd:string" />
 					<xsd:element name="picture" type="xsd:int" />
 					<xsd:element name="hidepicture" type="xsd:int" />
@@ -1037,6 +1038,7 @@
 					<xsd:element name="id" type="xsd:int" />
 					<xsd:element name="courseid" type="xsd:int" />
 					<xsd:element name="name" type="xsd:string" />
+					<xsd:element name="idnumber" type="xsd:string" />
 					<xsd:element name="description" type="xsd:string" />
 					<xsd:element name="enrolmentkey" type="xsd:string" />
 					<xsd:element name="picture" type="xsd:int" />

--- a/wspp/moodlewsdl.xml
+++ b/wspp/moodlewsdl.xml
@@ -152,6 +152,7 @@
 					<xsd:element name="id" type="xsd:int" />
 					<xsd:element name="courseid" type="xsd:int" />
 					<xsd:element name="name" type="xsd:string" />
+					<xsd:element name="idnumber" type="xsd:string" />
 					<xsd:element name="description" type="xsd:string" />
 					<xsd:element name="configdata" type="xsd:string" />
 					<xsd:element name="timecreated" type="xsd:int" />
@@ -1085,6 +1086,7 @@
 					<xsd:element name="id" type="xsd:int" />
 					<xsd:element name="courseid" type="xsd:int" />
 					<xsd:element name="name" type="xsd:string" />
+					<xsd:element name="idnumber" type="xsd:string" />
 					<xsd:element name="description" type="xsd:string" />
 
 				</xsd:all>

--- a/wspp/moodlewsdl2.xml
+++ b/wspp/moodlewsdl2.xml
@@ -373,6 +373,7 @@
           <xsd:element name="description" type="xsd:string"/>
           <xsd:element name="id" type="xsd:int"/>
           <xsd:element name="name" type="xsd:string"/>
+          <xsd:element name="idnumber" type="xsd:string"/>
         </xsd:all>
       </xsd:complexType>
       <xsd:complexType name="groupingRecordArray">
@@ -390,6 +391,7 @@
           <xsd:element name="error" type="xsd:string"/>
           <xsd:element name="id" type="xsd:int"/>
           <xsd:element name="name" type="xsd:string"/>
+          <xsd:element name="idnumber" type="xsd:string"/>
           <xsd:element name="timecreated" type="xsd:int"/>
           <xsd:element name="timemodified" type="xsd:int"/>
         </xsd:all>

--- a/wspp/moodlewsdl2.xml
+++ b/wspp/moodlewsdl2.xml
@@ -340,6 +340,7 @@
           <xsd:element name="hidepicture" type="xsd:int"/>
           <xsd:element name="id" type="xsd:int"/>
           <xsd:element name="name" type="xsd:string"/>
+          <xsd:element name="idnumber" type="xsd:string"/>
           <xsd:element name="picture" type="xsd:int"/>
         </xsd:all>
       </xsd:complexType>
@@ -359,6 +360,7 @@
           <xsd:element name="hidepicture" type="xsd:int"/>
           <xsd:element name="id" type="xsd:int"/>
           <xsd:element name="name" type="xsd:string"/>
+          <xsd:element name="idnumber" type="xsd:string"/>
           <xsd:element name="picture" type="xsd:int"/>
           <xsd:element name="timecreated" type="xsd:int"/>
           <xsd:element name="timemodified" type="xsd:int"/>


### PR DESCRIPTION
This pull request exposes the idnumber attribute of Group and Grouping operations that was added in Moodle 2.3+.

Groups and Groupings gained an 'idnumber' attribute in Moodle 2.3 as a result of MDL-32005:
https://tracker.moodle.org/browse/MDL-32005
This 'advanced' attribute can be used to map groups and groupings to external data sources.

This improvement allows me to use the web-service to auto-populate groups based on each course-section added to a Moodle course and keep the membership of that group up to date as students add and drop the course. Without this improvement, groups can only be matched on name --  a value that teachers are more likely to accidentally edit.
