### PR TITLE
Inconsistencies in the *_users_to_group functions and description

### DIFF
--- a/wspp/clients/classes/MoodleWS.php
+++ b/wspp/clients/classes/MoodleWS.php
@@ -3637,24 +3637,24 @@ class MoodleWS {
   }
 
   /**
-   * MoodleWS: Enrol students in a cohort 
+   * MoodleWS: Enrol students in a group
    *
    * @param int $client
    * @param string $sesskey
-   * @param string $courseid
-   * @param string $courseidfield
    * @param string[] $userids
    * @param string $useridfield
+   * @param string $groupid
+   * @param string $groupidfield
    * @return enrolStudentsReturn
    */
-  public function affect_users_to_group($client, $sesskey, $courseid, $courseidfield, $userids, $useridfield) {
+  public function affect_users_to_group($client, $sesskey, $userids, $useridfield, $groupid, $groupidfield) {
     $res= $this->client->__call('affect_users_to_group', array(
             new SoapParam($client, 'client'),
             new SoapParam($sesskey, 'sesskey'),
-            new SoapParam($courseid, 'courseid'),
-            new SoapParam($courseidfield, 'courseidfield'),
             new SoapParam($userids, 'userids'),
-            new SoapParam($useridfield, 'useridfield')
+            new SoapParam($useridfield, 'useridfield'),
+            new SoapParam($groupid, 'groupid'),
+            new SoapParam($groupidfield, 'groupidfield')
       ),
       array(
             'uri' => $this->uri ,
@@ -3665,24 +3665,24 @@ class MoodleWS {
   }
 
   /**
-   * MoodleWS: Unenrol students in a cohort 
+   * MoodleWS: Unenrol students in a group
    *
    * @param int $client
    * @param string $sesskey
-   * @param string $courseid
-   * @param string $courseidfield
    * @param string[] $userids
    * @param string $useridfield
+   * @param string $groupid
+   * @param string $groupidfield
    * @return enrolStudentsReturn
    */
-  public function remove_users_from_group($client, $sesskey, $courseid, $courseidfield, $userids, $useridfield) {
+  public function remove_users_from_group($client, $sesskey, $userids, $useridfield, $groupid, $groupidfield) {
     $res= $this->client->__call('remove_users_from_group', array(
             new SoapParam($client, 'client'),
             new SoapParam($sesskey, 'sesskey'),
-            new SoapParam($courseid, 'courseid'),
-            new SoapParam($courseidfield, 'courseidfield'),
             new SoapParam($userids, 'userids'),
-            new SoapParam($useridfield, 'useridfield')
+            new SoapParam($useridfield, 'useridfield'),
+            new SoapParam($groupid, 'groupid'),
+            new SoapParam($groupidfield, 'groupidfield')
       ),
       array(
             'uri' => $this->uri ,

--- a/wspp/server.class.php
+++ b/wspp/server.class.php
@@ -4412,7 +4412,7 @@ EOSS;
 
         foreach ($userids as $userid) {
             $st = new enrolRecord();
-            $st->setCourse($cohort->id);
+            $st->setCourse($group->id);
             $st->setUserid($userid);
 
             $a = new StdClass();
@@ -4424,7 +4424,7 @@ EOSS;
                 /// Check user is enroled in course
                 if (!ws_is_enrolled($group->courseid, $user->id)) {
 
-                    $st->error(get_string('ws_user_notenroled', 'local_wspp', $a));
+                    $st->error = get_string('ws_user_notenroled', 'local_wspp', $a);
                 } else {
                     if ($add) {
                         if (ws_get_record('groups_members', 'groupid', $group->id, 'userid', $user->id))


### PR DESCRIPTION
Hi, 
This pull request corrects some inconsistencies detected in the affect_users_to_group function:
Substituted the invalid variable $cohort->id to $group->id in st->setCourse($group->id);
Removed invalid call to method error (from the class EnrolRecord) substituted by assigning the error string to $st-> error

Corrected description of the parameters in the functions \* _users_to_group in wspp/clients/classes/MoodleWS.php
