### PR TITLE
Replacement of some deprecated code

### DIFF
--- a/wspp/clients/classes/MoodleWS.php
+++ b/wspp/clients/classes/MoodleWS.php
@@ -2925,6 +2925,32 @@ class MoodleWS {
   return $this->castTo ('affectRecord',$res);
   }
 
+    /**
+     * MoodleWS: Affect user to the category
+     *
+     * @param int $client
+     * @param string $sesskey
+     * @param int $userid
+     * @param int $categoryid
+     * @param string $rolename
+     * @return affectRecord
+     */
+    public function affect_user_to_category($client, $sesskey, $userid, $categoryid, $rolename) {
+        $res= $this->client->__call('affect_user_to_category', array(
+                new SoapParam($client, 'client'),
+                new SoapParam($sesskey, 'sesskey'),
+                new SoapParam($userid, 'userid'),
+                new SoapParam($categoryid, 'categoryid'),
+                new SoapParam($rolename, 'rolename')
+            ),
+            array(
+                'uri' => $this->uri ,
+                'soapaction' => ''
+            )
+        );
+        return $this->castTo ('affectRecord',$res);
+    }
+
   /**
    * MoodleWS: Affect a page of wiki to a wiki 
    *
@@ -2976,6 +3002,33 @@ class MoodleWS {
       );
   return $this->castTo ('affectRecord',$res);
   }
+    /**
+     * MoodleWS: Remove the role specified of the
+    user
+     * in the course
+     *
+     * @param int $client
+     * @param string $sesskey
+     * @param int $userid
+     * @param int $categoryid
+     * @param string $rolename
+     * @return affectRecord
+     */
+    public function remove_user_from_category($client, $sesskey, $userid, $categoryid, $rolename) {
+        $res= $this->client->__call('remove_user_from_category', array(
+                new SoapParam($client, 'client'),
+                new SoapParam($sesskey, 'sesskey'),
+                new SoapParam($userid, 'userid'),
+                new SoapParam($categoryid, 'categoryid'),
+                new SoapParam($rolename, 'rolename')
+            ),
+            array(
+                'uri' => $this->uri ,
+                'soapaction' => ''
+            )
+        );
+        return $this->castTo ('affectRecord',$res);
+    }
 
   /**
    * MoodleWS: Get All Groups 

--- a/wspp/clients/classes/mdl_soapserver.php
+++ b/wspp/clients/classes/mdl_soapserver.php
@@ -923,6 +923,32 @@ class mdl_soapserver {
   return $this->castTo ('affectRecord',$res);
   }
 
+    /**
+     *
+     *
+     * @param int $client
+     * @param string $sesskey
+     * @param int $userid
+     * @param int $categoryid
+     * @param string $rolename
+     * @return affectRecord
+     */
+    public function affect_user_to_category($client, $sesskey, $userid, $categoryid, $rolename) {
+        $res= $this->client->__call('affect_user_to_category', array(
+                new SoapParam($client, 'client'),
+                new SoapParam($sesskey, 'sesskey'),
+                new SoapParam($userid, 'userid'),
+                new SoapParam($categoryid, 'categoryid'),
+                new SoapParam($rolename, 'rolename')
+            ),
+            array(
+                'uri' => $this->uri ,
+                'soapaction' => ''
+            )
+        );
+        return $this->castTo ('affectRecord',$res);
+    }
+
   /**
    *  
    *
@@ -3632,6 +3658,32 @@ class mdl_soapserver {
       );
   return $this->castTo ('affectRecord',$res);
   }
+
+    /**
+     *
+     *
+     * @param int $client
+     * @param string $sesskey
+     * @param int $userid
+     * @param int $categoryid
+     * @param string $rolename
+     * @return affectRecord
+     */
+    public function remove_user_from_category($client, $sesskey, $userid, $categoryid, $rolename) {
+        $res= $this->client->__call('remove_user_from_category', array(
+                new SoapParam($client, 'client'),
+                new SoapParam($sesskey, 'sesskey'),
+                new SoapParam($userid, 'userid'),
+                new SoapParam($categoryid, 'categoryid'),
+                new SoapParam($rolename, 'rolename')
+            ),
+            array(
+                'uri' => $this->uri ,
+                'soapaction' => ''
+            )
+        );
+        return $this->castTo ('affectRecord',$res);
+    }
 
   /**
    *  

--- a/wspp/clients/classes/mdl_soapserverrest.php
+++ b/wspp/clients/classes/mdl_soapserverrest.php
@@ -837,6 +837,27 @@ class mdl_soapserverrest {
   return $this->castTo ('affectRecord',$res);
   }
 
+    /**
+     *
+     *
+     * @param int $client
+     * @param string $sesskey
+     * @param int $userid
+     * @param int $courseid
+     * @param string $rolename
+     * @return affectRecord
+     */
+    public function affect_user_to_category($client, $sesskey, $userid, $categoryid, $rolename) {
+        $res= $this->__call('affect_user_to_category', array(
+            'client'=>$client,
+            'sesskey'=>$sesskey,
+            'userid'=>$userid,
+            'categoryid'=>$categoryid,
+            'rolename'=>$rolename
+        ));
+        return $this->castTo ('affectRecord',$res);
+    }
+
   /**
    *  
    *
@@ -2976,6 +2997,27 @@ class mdl_soapserverrest {
       ));
   return $this->castTo ('affectRecord',$res);
   }
+
+    /**
+     *
+     *
+     * @param int $client
+     * @param string $sesskey
+     * @param int $userid
+     * @param int $categoryid
+     * @param string $rolename
+     * @return affectRecord
+     */
+    public function remove_user_from_category($client, $sesskey, $userid, $categoryid, $rolename) {
+        $res= $this->__call('remove_user_from_category', array(
+            'client'=>$client,
+            'sesskey'=>$sesskey,
+            'userid'=>$userid,
+            'categoryid'=>$categoryid,
+            'rolename'=>$rolename
+        ));
+        return $this->castTo ('affectRecord',$res);
+    }
 
   /**
    *  

--- a/wspp/filterlib.php
+++ b/wspp/filterlib.php
@@ -25,7 +25,7 @@ function filter_forum($client, $forum) {
         return $forum;
     if (!$cm = get_coursemodule_from_instance("forum", $forum->id, $forum->course))
         return false;
-    $context = get_context_instance(CONTEXT_MODULE, $cm->id);
+    $context = context_module::instance($cm->id);
     if (!has_capability('mod/forum:viewdiscussion', $context))
         return false;
     return $forum;
@@ -49,7 +49,7 @@ function filter_wiki($client, $wiki) {
         return $wiki;
     if (!$cm = get_coursemodule_from_instance("wiki", $wiki->id, $wiki->course))
         return false;
-    $context = get_context_instance(CONTEXT_MODULE, $cm->id);
+    $context = context_module::instance($cm->id);
     if (!has_capability('mod/wiki:participate', $context))
         return false;
     return $wiki;
@@ -82,7 +82,7 @@ function filter_pagewiki($client, $pagewiki) {
     if (!$cm = get_coursemodule_from_instance("wiki", $wiki->id, $course->id)) {
         return false;
     }
-    $context = get_context_instance(CONTEXT_MODULE, $cm->id);
+    $context = context_module::instance($cm->id);
     if (!has_capability('mod/wiki:participate', $context))
         return false;
 
@@ -107,7 +107,7 @@ function filter_assignment($client, $assignment) {
         return $assignment;
     if (!$cm = get_coursemodule_from_instance("assignment", $assignment->id, $assignment->course))
         return false;
-    $context = get_context_instance(CONTEXT_MODULE, $cm->id);
+    $context = context_module::instance($cm->id);
     if (!has_capability('mod/assignment:view', $context))
         return false;
      //fields renamed in Moodle 2.0
@@ -136,7 +136,7 @@ function filter_database($client, $database) {
         return $database;
     if (!$cm = get_coursemodule_from_instance("data", $database->id, $database->course))
         return false;
-    $context = get_context_instance(CONTEXT_MODULE, $cm->id);
+    $context = context_module::instance($cm->id);
     if (!has_capability('mod/data:viewentry', $context))
         return false;
     return $database;
@@ -158,7 +158,7 @@ function filter_label($client, $label) {
     // rev. 1.7 Moodle 2.0 now throw an execption if context is invalid (ie courseid==0)
     if (!empty ($label->error))
         return $label;
-    $context = get_context_instance(CONTEXT_COURSE, $label->course);
+    $context = context_course::instance($label->course);
     if (!ws_is_enrolled($label->course, $USER->id)) {
         return $label;
     }
@@ -231,7 +231,7 @@ function filter_course($client, $course) {
     //return false if not visible to $client
     // check capability , course maybe non visible
     //TODO ajouter ici le role primaire ;-)
-    $context = get_context_instance(CONTEXT_COURSE, $course->id);
+    $context = context_course::instance($course->id);
     if (has_capability('moodle/course:update', $context))
         return $course;
     if (ws_is_enrolled($course->id, $USER->id)) {
@@ -257,7 +257,7 @@ function filter_category($client, $category) {
     if (!empty ($category->error))
         return $category;
     //return false if not visible to $client
-    $context = get_context_instance(CONTEXT_COURSECAT, $category->id);
+    $context = context_category::instance($category->id);
     if (!$category->visible) {
         if (!has_capability('moodle/category:viewhiddencategories', $context))
             return false;
@@ -283,7 +283,7 @@ function filter_group($client, $group) {
     if (!empty ($group->error))
         return $group;
     // check user's membership to this group ?
-    $context = get_context_instance(CONTEXT_COURSE, $group->courseid);
+    $context = context_course::instance($group->courseid);
     if (has_capability('moodle/course:update', $context))
         return $group;
     if (!ws_is_enrolled($group->courseid, $USER->id))
@@ -308,7 +308,7 @@ function filter_grouping($client, $group) {
     if (!empty ($group->error))
         return $group;
     // check user's membership to this group ?
-    $context = get_context_instance(CONTEXT_COURSE, $group->courseid);
+    $context = context_course::instance($group->courseid);
     if (has_capability('moodle/course:update', $context))
         return $group;
     if (!ws_is_enrolled($group->courseid, $USER->id))
@@ -332,7 +332,7 @@ function filter_cohort($client, $group) {
     // rev. 1.7 Moodle 2.0 now throw an execption if context is invalid (ie courseid==0)
     if (!empty ($group->error))
         return $group;
-    $context = get_context_instance_by_id($group->contextid);
+    $context = context::instance_by_id($group->contextid);
     if (has_capability('moodle/cohort:manage', $context))
         return $group;
     return false;
@@ -363,7 +363,7 @@ function filter_resource($client, $resource) {
     }
 
     //return false if resource->visible is false AND $client not "teacher"
-    $context = get_context_instance(CONTEXT_COURSE, $resource->course);
+    $context = context_course::instance($resource->course);
     //if (has_capability('moodle/course:update', $context))
     // 1.6.3  there is a special capability for hiddensection
     if (has_capability('moodle/course:viewhiddenactivities', $context))
@@ -403,7 +403,7 @@ function filter_instance($client, $resource,$type) {
     }
 
     //return false if resource->visible is false AND $client not "teacher"
-    $context = get_context_instance(CONTEXT_COURSE, $resource->course);
+    $context = context_course::instance($resource->course);
     //if (has_capability('moodle/course:update', $context))
     // 1.6.3  there is a special capability for hiddensection
      if (has_capability('moodle/course:viewhiddenactivities', $context))
@@ -444,7 +444,7 @@ function filter_section($client, $section) {
     global $CFG,$USER;
     if (!empty ($section->error))
         return $section;
-    $context = get_context_instance(CONTEXT_COURSE, $section->course);
+    $context = context_course::instance($section->course);
     //if (has_capability('moodle/course:update', $context))
     // 1.6.3  there is a special capability for hiddensection
     if (has_capability('moodle/course:viewhiddensections', $context))
@@ -518,7 +518,7 @@ function filter_change($client, $change) {
     if (!empty ($change->error))
         return $change;
     //return false if ressource changed is not visible to $client
-    $context = get_context_instance(CONTEXT_COURSE, $change->courseid);
+    $context = context_course::instance($change->courseid);
     if (has_capability('moodle/course:update', $context))
         return $change;
     return $change->visible ? $change : false;
@@ -539,14 +539,14 @@ function filter_event($client, $eventype, $event) {
     // rev. 1.7 Moodle 2.0 now throw an execption if context is invalid (ie courseid==0)
     if (!empty ($event->error))
         return $event;
-    if (has_capability("moodle/calendar:manageentries", get_context_instance(CONTEXT_SYSTEM))) // admin user
+    if (has_capability("moodle/calendar:manageentries", context_system::instance())) // admin user
         return $event;
     switch ($eventype) {
         case cal_show_user :
             if ($event->userid != $USER->id)
                 return false;
             else {
-                if (has_capability("moodle/calendar:manageownentries", get_context_instance(CONTEXT_SYSTEM)))
+                if (has_capability("moodle/calendar:manageownentries", context_system::instance()))
                     return $event;
                 else
                     return false;

--- a/wspp/filterlib.php
+++ b/wspp/filterlib.php
@@ -257,7 +257,7 @@ function filter_category($client, $category) {
     if (!empty ($category->error))
         return $category;
     //return false if not visible to $client
-    $context = context_category::instance($category->id);
+    $context = context_coursecat::instance($category->id);
     if (!$category->visible) {
         if (!has_capability('moodle/category:viewhiddencategories', $context))
             return false;

--- a/wspp/genwsdl.php
+++ b/wspp/genwsdl.php
@@ -11,7 +11,7 @@
  // required Moodle 2.0
  define('CLI_SCRIPT', true);
 
- require_once ('../config.php');
+require(dirname(dirname(__FILE__)).'/config.php');
 
 define ('LIB_PATH','clients/lib/');
 require_once(LIB_PATH.'wshelper/WSDLStruct.class.php');

--- a/wspp/mdl_baseserver.class.php
+++ b/wspp/mdl_baseserver.class.php
@@ -2020,6 +2020,20 @@ abstract class mdl_baseserver extends server {
     }
 
     /**
+     * Assign role in category
+     * @param $client
+     * @param $sesskey
+     * @param $userid
+     * @param $categoryid
+     * @param $rolename
+     * @return affectRecord
+     */
+    function affect_user_to_category($client,$sesskey, $userid, $categoryid, $rolename) {
+        $rest = parent :: affect_user_to_category($client, $sesskey, $userid, $categoryid, $rolename);
+        return $this->send($this->to_single($rest, 'affectRecord'));
+    }
+
+    /**
      * @param int $client
      * @param string $sesskey
      * @param int $pageid
@@ -2041,6 +2055,19 @@ abstract class mdl_baseserver extends server {
      */
     function remove_user_from_course($client, $sesskey, $userid, $courseid, $rolename) {
         $rest = parent :: remove_user_from_course($client, $sesskey, $userid, $courseid, $rolename);
+        return $this->send($this->to_single($rest, 'affectRecord'));
+    }
+
+    /**
+     * @param int $client
+     * @param string $sesskey
+     * @param int $userid
+     * @param int $categoryid
+     * @param string $rolename
+     * @return affectRecord
+     */
+    function remove_user_from_category($client, $sesskey, $userid, $categoryid, $rolename) {
+        $rest = parent :: remove_user_from_category($client, $sesskey, $userid, $categoryid, $rolename);
         return $this->send($this->to_single($rest, 'affectRecord'));
     }
 

--- a/wspp/moodlewsdl2.xml
+++ b/wspp/moodlewsdl2.xml
@@ -1413,6 +1413,16 @@
   <message name="affect_user_to_courseResponse">
     <part name="affect_user_to_courseReturn" type="tns:affectRecord"/>
   </message>
+    <message name="affect_user_to_categoryRequest">
+        <part name="client" type="xsd:int"/>
+        <part name="sesskey" type="xsd:string"/>
+        <part name="userid" type="xsd:int"/>
+        <part name="categoryid" type="xsd:int"/>
+        <part name="rolename" type="xsd:string"/>
+    </message>
+    <message name="affect_user_to_categoryResponse">
+        <part name="affect_user_to_categoryReturn" type="tns:affectRecord"/>
+    </message>
   <message name="affect_user_to_groupRequest">
     <part name="client" type="xsd:int"/>
     <part name="sesskey" type="xsd:string"/>
@@ -2420,6 +2430,16 @@
   <message name="remove_user_from_courseResponse">
     <part name="remove_user_from_courseReturn" type="tns:affectRecord"/>
   </message>
+    <message name="remove_user_from_categoryRequest">
+        <part name="client" type="xsd:int"/>
+        <part name="sesskey" type="xsd:string"/>
+        <part name="userid" type="xsd:int"/>
+        <part name="categoryid" type="xsd:int"/>
+        <part name="rolename" type="xsd:string"/>
+    </message>
+    <message name="remove_user_from_categoryResponse">
+        <part name="remove_user_from_categoryReturn" type="tns:affectRecord"/>
+    </message>
   <message name="remove_user_from_groupRequest">
     <part name="client" type="xsd:int"/>
     <part name="sesskey" type="xsd:string"/>
@@ -2639,6 +2659,10 @@
       <wsdl:input message="tns:affect_user_to_courseRequest"/>
       <wsdl:output message="tns:affect_user_to_courseResponse"/>
     </wsdl:operation>
+      <wsdl:operation name="affect_user_to_category">
+          <wsdl:input message="tns:affect_user_to_categoryRequest"/>
+          <wsdl:output message="tns:affect_user_to_categoryResponse"/>
+      </wsdl:operation>
     <wsdl:operation name="affect_user_to_group">
       <wsdl:input message="tns:affect_user_to_groupRequest"/>
       <wsdl:output message="tns:affect_user_to_groupResponse"/>
@@ -3094,6 +3118,10 @@
       <wsdl:input message="tns:remove_user_from_courseRequest"/>
       <wsdl:output message="tns:remove_user_from_courseResponse"/>
     </wsdl:operation>
+      <wsdl:operation name="remove_user_from_category">
+          <wsdl:input message="tns:remove_user_from_categoryRequest"/>
+          <wsdl:output message="tns:remove_user_from_categoryResponse"/>
+      </wsdl:operation>
     <wsdl:operation name="remove_user_from_group">
       <wsdl:input message="tns:remove_user_from_groupRequest"/>
       <wsdl:output message="tns:remove_user_from_groupResponse"/>
@@ -3393,6 +3421,15 @@
         <soap:body use="encoded" namespace="CFGWWWROOT/wspp/wsdl2" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
       </wsdl:output>
     </wsdl:operation>
+      <wsdl:operation name="affect_user_to_category">
+          <soap:operation soapAction="CFGWWWROOT/wspp/service_pp2.php&amp;method=affect_user_to_category" style="rpc"/>
+          <wsdl:input>
+              <soap:body use="encoded" namespace="CFGWWWROOT/wspp/wsdl2" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+          </wsdl:input>
+          <wsdl:output>
+              <soap:body use="encoded" namespace="CFGWWWROOT/wspp/wsdl2" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+          </wsdl:output>
+      </wsdl:operation>
     <wsdl:operation name="affect_user_to_group">
       <soap:operation soapAction="CFGWWWROOT/wspp/service_pp2.php&amp;method=affect_user_to_group" style="rpc"/>
       <wsdl:input>
@@ -4416,6 +4453,15 @@
         <soap:body use="encoded" namespace="CFGWWWROOT/wspp/wsdl2" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
       </wsdl:output>
     </wsdl:operation>
+      <wsdl:operation name="remove_user_from_category">
+          <soap:operation soapAction="CFGWWWROOT/wspp/service_pp2.php&amp;method=remove_user_from_category" style="rpc"/>
+          <wsdl:input>
+              <soap:body use="encoded" namespace="CFGWWWROOT/wspp/wsdl2" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+          </wsdl:input>
+          <wsdl:output>
+              <soap:body use="encoded" namespace="CFGWWWROOT/wspp/wsdl2" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/>
+          </wsdl:output>
+      </wsdl:operation>
     <wsdl:operation name="remove_user_from_group">
       <soap:operation soapAction="CFGWWWROOT/wspp/service_pp2.php&amp;method=remove_user_from_group" style="rpc"/>
       <wsdl:input>

--- a/wspp/server.class.php
+++ b/wspp/server.class.php
@@ -4417,7 +4417,7 @@ EOSS;
 
             $a = new StdClass();
             $a->user = $userid;
-            $a->course = $groupid;
+            $a->course = $group->courseid;
             if (!$user = ws_get_record('user', $useridfield, $userid)) {
                 $st->error = get_string('ws_userunknown', 'local_wspp', $useridfield . "=" . $userid);
             } else {

--- a/wspp/server.class.php
+++ b/wspp/server.class.php
@@ -2868,7 +2868,7 @@ EOSS;
                             break;
                         }
                         $context = context_category::instance($cid);
-                        mark_context_dirty($context->path);
+                        $context->mark_dirty();
                         fix_course_sortorder(); // Required to build course_categories.depth and .path.
 
                         $ret = ws_get_record('course_categories', 'id', $cid);

--- a/wspp/wslib.php
+++ b/wspp/wslib.php
@@ -241,7 +241,7 @@ function ws_get_my_courses($uid, $sort='',$extrafields=array()) {
 	global $CFG,$DB;
 	if ($CFG->wspp_using_moodle20) {
 		try {
-			 $context = get_context_instance(CONTEXT_SYSTEM);
+			 $context = context_system::instance();
 
     		if (has_capability('moodle/course:create' , $context, $uid,true)) {
 				//ws_error_log ("ok admin\n");
@@ -332,8 +332,8 @@ function ws_role_assign($roleid, $userid, $contextid, $timestart, $timeend,$cour
  */
 function ws_get_primaryrole_incourse($course, $userid) {
 	global $CFG;
-	$context = get_context_instance(CONTEXT_COURSE, $course->id);
-	$context_cat = get_context_instance(CONTEXT_COURSECAT, $course->category);
+	$context = context_course::instance($course->id);
+	$context_cat = context_category::instance($course->category);
 	if ($context_cat && has_capability('moodle/category:manage', $context_cat, $userid))
 		return 1;
 	if ($context_cat && has_capability('moodle/course:create', $context_cat, $userid))
@@ -362,7 +362,7 @@ function ws_get_primaryrole_incourse($course, $userid) {
  */
 function ws_is_enrolled ($courseid,$userid) {
 	global $CFG;
-	$context = get_context_instance(CONTEXT_COURSE, $courseid);
+	$context = context_course::instance($courseid);
 	if (!$CFG->wspp_using_moodle20) {
 		return has_capability('moodle/course:view', $context, $userid, false);
 	} else {

--- a/wspp/wslib.php
+++ b/wspp/wslib.php
@@ -333,7 +333,7 @@ function ws_role_assign($roleid, $userid, $contextid, $timestart, $timeend,$cour
 function ws_get_primaryrole_incourse($course, $userid) {
 	global $CFG;
 	$context = context_course::instance($course->id);
-	$context_cat = context_category::instance($course->category);
+	$context_cat = context_coursecat::instance($course->category);
 	if ($context_cat && has_capability('moodle/category:manage', $context_cat, $userid))
 		return 1;
 	if ($context_cat && has_capability('moodle/course:create', $context_cat, $userid))


### PR DESCRIPTION
Hi, 
This pull request aims to correct some inconsistencies detected in variable names and declaration, but mostly to update some deprecated code, accordingly to the new moodle standards, namely the  'get_context_.....' functions, that will be deprecated in Moodle 2.8, with context_xxxx:: , move_category --> coursecat::get($category->id)->change_parent($newparentcat->id) and mark_context_dirty($path) to $context->mark_dirty();

Greetings,
Micael Rodrgiues
